### PR TITLE
fix(twitter-user): remove name attribute from TwitterUser model, services, routes and tests

### DIFF
--- a/src/calculator/models.ts
+++ b/src/calculator/models.ts
@@ -15,7 +15,6 @@ export interface TweetCredibilityWeights extends TextCredibilityWeights {
 }
 
 export interface TwitterUser {
-  name: string
   verified: boolean
   yearJoined: number
   followersCount: number

--- a/src/calculator/routes.ts
+++ b/src/calculator/routes.ts
@@ -87,7 +87,6 @@ calculatorRoutes.get('/tweets/scraped', validate('scrapedTweetCredibility'), asy
     weightSocial: +req.query.weightSocial,
   },
   {
-    name: '',
     verified: req.query.verified === 'true',
     yearJoined: +req.query.yearJoined,
     followersCount: +req.query.followersCount,

--- a/src/calculator/service.ts
+++ b/src/calculator/service.ts
@@ -39,7 +39,6 @@ const spellingCheckers = {
 
 function responseToTwitterUser(response: any) : TwitterUser {
   return {
-    name: response.name,
     verified: response.verified,
     yearJoined: response.created_at.split(' ').pop(),
     followersCount: response.followers_count,
@@ -188,7 +187,6 @@ async function twitterUserCredibility(userId: string) {
 
 function scrapperTwitterUserCredibility(verified: boolean, accountCreationYear: number) : Credibility{
   const user:  TwitterUser = {
-    name: '',
     verified: verified,
     yearJoined: accountCreationYear,
     followersCount: 0,
@@ -266,7 +264,6 @@ async function scrapedtweetCredibility(tweetText: Text, tweetCredibilityWeights:
 
 function scrapedSocialCredibility(followersCount: number, friendsCount: number, maxFollowers: number){
   const user : TwitterUser = {
-    name: '',
     verified: false,
     yearJoined: 2018,
     followersCount: followersCount,

--- a/tests/calculus-endpoints/social-api.test.ts
+++ b/tests/calculus-endpoints/social-api.test.ts
@@ -12,7 +12,6 @@ describe('/calculate/twitter/social/:userId endpoint', () => {
     Twit.prototype.get = jest.fn((path: string, params?: any) =>new Promise((resolve:any, reject:any) => resolve({
       data: {
         id: 91891658,
-        name: 'Test name',
         followers_count: 116,
         friends_count: 138,
         created_at: 'Mon Feb 21 01:59:02 +0000 2011',

--- a/tests/calculus-endpoints/social-scrapped.test.ts
+++ b/tests/calculus-endpoints/social-scrapped.test.ts
@@ -16,7 +16,6 @@ describe('/calculate/social/scrape endpoint', () => {
 
     describe('1.200.000 followers, 421 following', () => {
       const params = {
-        name: '',
         verified: false,
         yearJoined: 2000,
         followersCount: 1200000,
@@ -30,7 +29,6 @@ describe('/calculate/social/scrape endpoint', () => {
 
     describe('5.000.000 followers, 421 following, 2.000.000 MaxFollowers', () => {
       const params = {
-        name: '',
         verified: false,
         yearJoined: 2000,
         followersCount: 5000000,
@@ -46,7 +44,6 @@ describe('/calculate/social/scrape endpoint', () => {
     // the 0,0 pair should return.
     // describe('zero followers, zero following', () => {
     //   const params = {
-    //     name: '',
     //     verified: false,
     //     yearJoined: 2000      
     //   }
@@ -72,7 +69,6 @@ describe('/calculate/social/scrape endpoint', () => {
 
     describe('negative followers, positive followings', () => {
       const params = {
-        name: '',
         verified: false,
         yearJoined: 2000,
         followersCount: -1,

--- a/tests/calculus-endpoints/tweet-api.test.ts
+++ b/tests/calculus-endpoints/tweet-api.test.ts
@@ -15,7 +15,6 @@ describe('/twitter/tweets', () => {
         lang: 'en',
         user: {
           id: 91891658,
-          name: 'Test name',
           followers_count: 0,
           friends_count: 0,
           created_at: 'Mon Feb 21 01:59:02 +0000 2011',

--- a/tests/calculus-endpoints/tweet-scrapped.test.ts
+++ b/tests/calculus-endpoints/tweet-scrapped.test.ts
@@ -27,7 +27,6 @@ describe('/calculate/tweets/scraped endpoint', () => {
         weightSocial: 0,
       }
       const twitterUser : TwitterUser = {
-        name: '',
         verified: false,
         yearJoined: 2010,
         followersCount: 2000,
@@ -62,7 +61,6 @@ describe('/calculate/tweets/scraped endpoint', () => {
         weightSocial: 0
       }
       const twitterUser : TwitterUser = {
-        name: '',
         verified: true,
         yearJoined: 2006,
         friendsCount: 2000,
@@ -120,7 +118,6 @@ describe('/calculate/tweets/scraped endpoint', () => {
         weightSocial: 1
       }
       const twitterUser : TwitterUser = {
-        name: '',
         verified: true,
         yearJoined: 2006,
         friendsCount: 2000,

--- a/tests/calculus-endpoints/user-api.test.ts
+++ b/tests/calculus-endpoints/user-api.test.ts
@@ -16,7 +16,6 @@ describe('/twitter/user/:id endpoint', () => {
     Twit.prototype.get = jest.fn((path: string, params?: any) =>new Promise((resolve:any, reject:any) => resolve({
       data: {
         id: 91891658,
-        name: 'Test name',
         followers_count: 116,
         friends_count: 138,
         created_at: 'Mon Feb 21 01:59:02 +0000 2011',

--- a/tests/calculus-endpoints/user-scrapped.test.ts
+++ b/tests/calculus-endpoints/user-scrapped.test.ts
@@ -19,7 +19,6 @@ describe('/user/scrape endpoint', () => {
     }
     describe('verified true, year joined 2006', () => {
       const params = {
-        name: 'f',
         followersCount: 123,
         friendsCount: 12
       }


### PR DESCRIPTION
There was an extra parameter that was being unused. This PR just remove it.

thankfully, this doesn't add any breaking changes.
